### PR TITLE
Initial try to get Cookies in the OOI Model

### DIFF
--- a/octopoes/models/ooi/web.py
+++ b/octopoes/models/ooi/web.py
@@ -10,6 +10,9 @@ from octopoes.models.ooi.network import IPAddress, Network
 from octopoes.models.ooi.service import IPService
 from octopoes.models.persistence import ReferenceField
 
+from http.cookies import SimpleCookie, CookieError
+from datetime import datetime, timedelta, timezone
+
 
 class Website(OOI):
     object_type: Literal["Website"] = "Website"
@@ -194,3 +197,95 @@ class HTTPHeaderHostname(OOI):
         address = t.resource.website.ip_service.ip_port.address.address
 
         return f"{t.key} @ {web_url} @ {address} contains {str(reference.tokenized.hostname.name)}"
+
+
+class HTTPCookie(OOI):
+    # https://datatracker.ietf.org/doc/html/rfc6265
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
+    object_type: Literal["HTTPCookie"] = "HTTPCookie"
+
+    _natural_key_attrs = [
+        "name",
+        "domain",
+        "path",
+    ]  # does not include network, as there is not concept of a network only hostnames in the browsers cookie handling.
+
+    # httpheader: Reference(ReferenceField(HTTPHeaderURL, max_inherit_scan_level=4))  # ideally we should keep track of which header was parsed into this cookie object
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3
+    name: str
+    value: str
+    expirytime: Optional[datetime]
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p6
+    domain: Reference = ReferenceField(Hostname, max_inherit_scan_level=4)
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p7
+    path: str = "/"
+    creationtime: datetime
+    # last-access-time: # not used in openkat context
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p3
+    persistent: bool = False
+
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p6
+    hostonly: bool = False
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p8
+    secureonly: bool = False
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p9
+    httponly: bool = False
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+    samesite: bool = False
+    maxage: Optional[int]
+
+    @classmethod
+    def format_reference_human_readable(cls, reference: Reference) -> str:
+        tokenized = reference.tokenized
+        return f"{tokenized.name} @ {tokenized.domain}"
+
+    @classmethod
+    def fromstring(cls, responsedomain, cookie) -> Iterator[OOI]:
+        now = datetime.now(timezone.utc)
+        # https://docs.python.org/3/library/http.cookies.html
+        try:
+            parsedcookie = SimpleCookie(cookie)
+        except CookieError as cookieerror:
+            yield Finding(cookieerror)
+        for name, morsel in parsedcookie.items():
+            # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p6
+            hostonly = False
+            if not morsel.domain:
+                hostonly = True
+                morsel.domain = responsedomain
+
+            # https://datatracker.ietf.org/doc/html/rfc6265#section-5.3 p3
+            persistent = False
+            expires = float("inf")
+            if "max-age" in morsel:
+                persistent = True
+                try:
+                    maxage = min(
+                        1e8, int(morsel["max-age"])
+                    )  # limit to make sure we dont trip over calculating a date millions of years in the future
+                except ValueError:
+                    persistent = False
+                else:
+                    expires = now + timedelta(maxage)
+
+            elif morsel.expires:
+                persistent = True
+                expires = datetime.strptime(morsel.expires)
+
+            domain = Reference.from_str(morsel.domain)  # load or create?
+            domain = Reference.from_str(morsel.domain)  # load or create?
+            yield HTTPCookie(
+                httpheader=httpheader,
+                name=name,
+                value=morsel.value,
+                expirytime=morsel.expires,
+                domain=domain,
+                path=morsel.path or "/",
+                creationtime=now,
+                persistent=persistent,
+                hostonly=hostonly,
+                secureonly=morsel.secure,
+                httponly=morsel.httponly,
+                samesite=morsel.samesite,
+                maxage=maxage,
+            )


### PR DESCRIPTION
## Changes
Add Cookies to the OOI model

## Checklist for author(s):
- [X] This PR comes from a `feature` or `hotfix` branch, in line with our git branching strategy;
- [X] This PR is "bite-sized" and only focuses on a single issue, problem, or feature;
- [ ] If a non-trivial PR: This PR is properly linked to the project board (either directly or via an issue);
- [ ] If a non-trivial PR: I have added screenshots or some other proof that my code does what it is supposed to do;
- [ ] I am not reinventing the wheel: there is no high-quality library that already has this feature;
- [ ] I have changed the example `.env` files if I added, removed, or changed any config options, and I have informed others that they need to modify their `.env` files if required;
- [ ] I have performed a self-review of my own code;
- [X] I have commented my code, particularly in hard-to-understand areas;
- [ ] I have made corresponding changes to the documentation, if necessary;
- [ ] I have written unit, integration, and end-to-end tests for the change that I made;


```
## Checklist for functional reviewer(s):
- [ ] If a non-trivial PR: This PR is properly linked to an issue on the project board;
- [ ] I have checked out this branch, and successfully ran `make kat`;
- [ ] I have ran `make test-rf` and all end-to-end Robot Framework tests pass;
- [ ] I confirmed that the PR's advertised `feature` or `hotfix` works as intended;
- [ ] I confirmed that there are no unintended functional regressions in this branch;

### What works:
* _bullet point + screenshot (if useful) per tested functionality_

### What doesn't work:
* _bullet point + screenshot (if useful) per tested functionality_

### Bug or feature?:
* Add HTTPCookie objects that we can create from HTTPHeaders that contain the set-cookie directive.

```
## Checklist for code reviewer(s):
- [ ] The code passes the CI tests and linters;
- [ ] The code does not bypass authentication or security mechanisms;
- [X] The code does not introduce any dependency on a library that has not been properly vetted;
- [ ] The code does not violate Model-View-Template and our other architectural principles;
- [ ] The code contains docstrings, comments, and documentation where needed;
- [ ] The code prioritizes readability over performance where appropriate;
- [ ] The code conforms to our agreed coding standards.
```
