### PR TITLE
ignore double quotes before spf parsing

### DIFF
--- a/bits/spf_discovery/spf_discovery.py
+++ b/bits/spf_discovery/spf_discovery.py
@@ -18,7 +18,7 @@ def run(
     if input_ooi.value.startswith("v=spf1"):
         spf_value = input_ooi.value.replace("%(d)", input_ooi.hostname.tokenized.name)
         # long spf records are split into multiple txt records, that can be concatenated
-        spf_value = spf_value.replace('" "', " ")
+        spf_value = spf_value.replace('" "', "")
         parsed = parse(spf_value)
         # check if spf record passes the internet.nl parser
         if parsed is not None:

--- a/bits/spf_discovery/spf_discovery.py
+++ b/bits/spf_discovery/spf_discovery.py
@@ -17,6 +17,8 @@ def run(
 
     if input_ooi.value.startswith("v=spf1"):
         spf_value = input_ooi.value.replace("%(d)", input_ooi.hostname.tokenized.name)
+        # long spf records are split into multiple txt records, that can be concatenated
+        spf_value = spf_value.replace('" "', " ")
         parsed = parse(spf_value)
         # check if spf record passes the internet.nl parser
         if parsed is not None:


### PR DESCRIPTION
According to RFC

3.3.  Multiple Strings in a Single DNS Record

   As defined in [RFC1035], Sections 3.3 and 3.3.14, a single text DNS
   record can be composed of more than one string.  If a published
   record contains multiple character-strings, then the record MUST be
   treated as if those strings are concatenated together without adding
   spaces.  For example:

      IN TXT "v=spf1 .... first" "second string..."

   is equivalent to:

      IN TXT "v=spf1 .... firstsecond string..."

   TXT records containing multiple strings are useful in constructing
   records that would exceed the 255-octet maximum length of a
   character-string within a single TXT record.
